### PR TITLE
Sessions reject connections with differing appVersion

### DIFF
--- a/ChroMapTogether/Controllers/CreateServerController.cs
+++ b/ChroMapTogether/Controllers/CreateServerController.cs
@@ -1,5 +1,6 @@
-﻿using ChroMapTogether.Configuration;
+using ChroMapTogether.Configuration;
 using ChroMapTogether.Models;
+using ChroMapTogether.Models.Requests;
 using ChroMapTogether.Models.Responses;
 using ChroMapTogether.Providers;
 using ChroMapTogether.Registries;
@@ -26,14 +27,15 @@ namespace ChroMapTogether.Controllers
         }
 
         [HttpPost]
-        public ActionResult Post()
+        public ActionResult Post([FromForm] CreateSessionRequest request)
         {
             var session = new Session
             {
                 Guid = Guid.NewGuid(),
                 Ip = Request.HttpContext.Connection.RemoteIpAddress!.MapToIPv4().ToString(),
                 Port = 6969,
-                Code = codeProvider.Generate(config.Value.RoomCodeLength)
+                Code = codeProvider.Generate(config.Value.RoomCodeLength),
+                AppVersion = request.appVersion
             };
 
             sessionRegistry.AddSession(session);

--- a/ChroMapTogether/Controllers/JoinServerController.cs
+++ b/ChroMapTogether/Controllers/JoinServerController.cs
@@ -23,7 +23,8 @@ namespace ChroMapTogether.Controllers
                 : Ok(new JoinSessionResponse
                 {
                     ip = server.Ip,
-                    port = server.Port
+                    port = server.Port,
+                    appVersion = server.AppVersion
                 });
         }
     }

--- a/ChroMapTogether/Models/Requests/CreateSessionRequest.cs
+++ b/ChroMapTogether/Models/Requests/CreateSessionRequest.cs
@@ -1,0 +1,7 @@
+namespace ChroMapTogether.Models.Requests
+{
+    public class CreateSessionRequest
+    {
+        public string appVersion { get; set; } = string.Empty;
+    }
+}

--- a/ChroMapTogether/Models/Responses/JoinSessionResponse.cs
+++ b/ChroMapTogether/Models/Responses/JoinSessionResponse.cs
@@ -4,5 +4,6 @@
     {
         public string ip { get; set; } = string.Empty;
         public int port { get; set; }
+        public string appVersion { get; set; } = string.Empty;
     }
 }

--- a/ChroMapTogether/Models/Session.cs
+++ b/ChroMapTogether/Models/Session.cs
@@ -12,6 +12,7 @@ namespace ChroMapTogether.Models
         public string Ip { get; set; } = string.Empty;
         public int Port { get; set; }
         public string Code { get; set; } = string.Empty;
+        public string AppVersion { get; set; } = string.Empty;
         public DateTime Expiry { get; set; } = DateTime.MaxValue;
 
         public NetPeer? Host { get; set; } = null;

--- a/ChroMapTogether/Properties/launchSettings.json
+++ b/ChroMapTogether/Properties/launchSettings.json
@@ -24,7 +24,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
       "applicationUrl": "https://localhost:5001;http://localhost:5000",
-      "dotnetRunMessages": "true"
+      "dotnetRunMessages": true
     }
   }
 }

--- a/ChroMapTogether/UDP/Packets/MapperIdentityPacket.cs
+++ b/ChroMapTogether/UDP/Packets/MapperIdentityPacket.cs
@@ -9,6 +9,7 @@ namespace ChroMapTogether.UDP.Packets
         public int ConnectionId = int.MinValue;
         public MapperColor Color = new(0, 0, 0);
         public long DiscordId = -1;
+        public string AppVersion = string.Empty;
 
         public NetPeer? MapperPeer;
 
@@ -20,6 +21,9 @@ namespace ChroMapTogether.UDP.Packets
             Name = reader.GetString();
             Color = new(reader.GetFloat(), reader.GetFloat(), reader.GetFloat());
             DiscordId = reader.GetLong();
+
+            // Stable CM currently doesn't send appVersion
+            AppVersion = reader.TryGetString(out var version) ? version : ""; 
         }
 
         public void Serialize(NetDataWriter writer)
@@ -30,6 +34,7 @@ namespace ChroMapTogether.UDP.Packets
             writer.Put(Color.g);
             writer.Put(Color.b);
             writer.Put(DiscordId);
+            writer.Put(AppVersion);
         }
 
         public record MapperColor(float r, float g, float b);

--- a/ChroMapTogether/UDP/UDPServer.cs
+++ b/ChroMapTogether/UDP/UDPServer.cs
@@ -61,11 +61,17 @@ namespace ChroMapTogether.UDP
                 && roomCode.Length == serverConfig.Value.RoomCodeLength
                 && sessionRegistry.TryGetSession(roomCode, out var session))
             {
+                var identity = request.Data.Get<MapperIdentityPacket>();
+
+                if (session.AppVersion != identity.AppVersion)
+                {
+                    request.Reject();
+                    return;
+                }
+
                 var peer = request.Accept();
 
                 session.Host ??= peer;
-
-                var identity = request.Data.Get<MapperIdentityPacket>();
                 identity.ConnectionId = session.Identities.Count;
                 identity.MapperPeer = peer;
 
@@ -239,7 +245,7 @@ namespace ChroMapTogether.UDP
         }
 
         public void WriteNet(NetLogLevel level, string str, params object[] args) => logger.Information(str, args);
-        
+
         public void SendPacketFrom(MapperIdentityPacket fromPeer, NetPeer toPeer, PacketId packetId)
         {
             var writer = new NetDataWriter();

--- a/ChroMapTogether/api/chromaptogether.v1.yaml
+++ b/ChroMapTogether/api/chromaptogether.v1.yaml
@@ -15,11 +15,20 @@ info:
     direct connections to work.
   contact:
     name: Caeden117
-  version: 1.0.0
+  version: 1.1.0
 paths:
   /CreateServer:
     post:
       summary: 'Creates a new room code for a ChroMapper United Mapping session.'
+      requestBody:
+        content:
+          'application/x-www-form-urlencoded':
+            schema:
+             type: object
+             properties:
+                appVersion: 
+                  description: The application version
+                  type: string
       responses:
         '200':
           description: |-
@@ -72,11 +81,15 @@ paths:
                   port:
                     type: number
                     description: Host port
+                  appVersion:
+                    type: string
+                    description: Host app version
               examples:
                 Default Response:
                   value:
                     ip: '127.0.0.1'
                     port: 6969
+                    appVersion: 0.9.0
         '404':
           description: No server with join code exists.
   /KeepServerAlive:


### PR DESCRIPTION
This adds an optional `appVersion` to the CreateServer POST api which the session will store. Sessions will now reject connection if the identity AppVersion is different. This prevents dev and stable CM from connecting via roomcode and leaves stable CM intact (using empty string for its appVersion).

This new feature is used in this [CM PR on these lines](https://github.com/Caeden117/ChroMapper/pull/476/files#diff-a5e0480174501d81a6beab79394a9964b386530199222c31365e87610a816d77R43-R45).